### PR TITLE
#13 - userAccount 도메인 API 노출 방지 테스트 코드 추가

### DIFF
--- a/src/test/java/com/fastcampus/mvcboardproject/controller/DataRestTest.java
+++ b/src/test/java/com/fastcampus/mvcboardproject/controller/DataRestTest.java
@@ -9,7 +9,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -68,4 +68,20 @@ public class DataRestTest {
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
     }
+
+    @DisplayName("[api] 회원 관련 API 는 일체 제공하지 않는다.")
+    // 회원 관련 DB는 제공하지 않기 위해 해당 api테스트를 구현함. 404 페이지가 나오도록
+    @Test
+    void givenNothing_whenRequestingUserAccounts_thenThrowsException() throws Exception {
+        // Given
+
+        // When & Then
+        mvc.perform(get("/api/userAccounts")).andExpect(status().isNotFound());
+        mvc.perform(post("/api/userAccounts")).andExpect(status().isNotFound());
+        mvc.perform(put("/api/userAccounts")).andExpect(status().isNotFound());
+        mvc.perform(patch("/api/userAccounts")).andExpect(status().isNotFound());
+        mvc.perform(delete("/api/userAccounts")).andExpect(status().isNotFound());
+        mvc.perform(head("/api/userAccounts")).andExpect(status().isNotFound());
+    }
+
 }


### PR DESCRIPTION
UserAccount 도메인을 반영하여 회원 정보가 API에 노출되지 않도록 404  not found를 확인하는 테스트를 추가했음. 
모든 http메소드에 대응하도록 함.