### PR TITLE
잘못된 도메인 정보 바로잡기

### DIFF
--- a/src/main/java/com/fastcampus/mvcboardproject/domain/UserAccount.java
+++ b/src/main/java/com/fastcampus/mvcboardproject/domain/UserAccount.java
@@ -9,7 +9,7 @@ import java.util.Objects;
 @Setter
 @ToString(callSuper = true)
 @Table(indexes = { //검색을 위한 index를 설정
-        @Index(columnList = "userId"),
+        @Index(columnList = "userId", unique = true),
         @Index(columnList = "email", unique = true),
         @Index(columnList = "createdAt"),
         @Index(columnList = "createdBy")

--- a/src/test/java/com/fastcampus/mvcboardproject/repository/JpaRepositoryTest.java
+++ b/src/test/java/com/fastcampus/mvcboardproject/repository/JpaRepositoryTest.java
@@ -49,7 +49,7 @@ class JpaRepositoryTest {
     void givenTestData_whenInserting_thenWorksFine() {
         // Given
         long previousCount = articleRepository.count();
-        UserAccount userAccount = userAccountRepository.save(UserAccount.of("uno", "pw", null, null, null));
+        UserAccount userAccount = userAccountRepository.save(UserAccount.of("newUno", "pw", null, null, null));
 
         // When
         articleRepository.save(Article.of(userAccount, "new title","new content", "#spring"));


### PR DESCRIPTION
#34 기능 구현 중 도메인 코드 설계가 일부 잘못 되어있는 것을 발견하였음.

UserAccount 회원 계정의 userId 는 회원 id 이므로 유니크해야 하는데, 해당 속성이 빠져있었음.

erd 문서에는 email 의 유니크 키가 표현되지 않음
바로잡음.