### PR TITLE
#39 - 해시태그 검색 페이지와 관련 기능 구현

### DIFF
--- a/src/main/java/com/fastcampus/mvcboardproject/controller/ArticleController.java
+++ b/src/main/java/com/fastcampus/mvcboardproject/controller/ArticleController.java
@@ -6,6 +6,7 @@ import com.fastcampus.mvcboardproject.dto.response.ArticleWithCommentsResponse;
 import com.fastcampus.mvcboardproject.service.ArticleService;
 import com.fastcampus.mvcboardproject.service.PaginationService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -25,6 +26,7 @@ import java.util.List;
     /api/aricles/{article-id}
     /api/article/{article-id}/articleComments
  */
+@Slf4j
 @RequiredArgsConstructor
 @RequestMapping("/articles")
 @Controller
@@ -62,6 +64,33 @@ public class ArticleController {
         map.addAttribute("articleComments", article.articleCommentsResponse());
 
         return "articles/detail";
+    }
+
+    @GetMapping("/search-hashtag")
+    public String searchHashtag(
+            @RequestParam(required = false) String searchValue,
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
+            ModelMap map
+    ) {
+        log.error("[컨트롤러] search-hashtag 확인, searchValue: {}", searchValue);
+
+        Page<ArticleResponse> articles = articleService.searchArticlesViaHashtag(searchValue, pageable).map(ArticleResponse::from);
+        log.error("[컨트롤러] searchArticlesViaHashtag에서 패스");
+        
+        List<Integer> barNumbers = paginationService.getPaginationBarNumbers(pageable.getPageNumber(), articles.getTotalPages());
+        log.error("[컨트롤러] getPaginationBarNumbers에서 패스");
+        
+        List<String> hashtags = articleService.getHashtags();
+        log.error("[컨트롤러] getHashtags에서 패스");
+
+        log.error("[컨트롤러] articles: {}, barNumbers: {}, hashtag: {}", articles, barNumbers, hashtags);
+
+        map.addAttribute("articles", articles);
+        map.addAttribute("hashtags", hashtags);
+        map.addAttribute("paginationBarNumbers", barNumbers);
+        map.addAttribute("searchType", SearchType.HASHTAG);
+
+        return "articles/search-hashtag";
     }
 
 }

--- a/src/main/java/com/fastcampus/mvcboardproject/controller/ArticleController.java
+++ b/src/main/java/com/fastcampus/mvcboardproject/controller/ArticleController.java
@@ -49,6 +49,7 @@ public class ArticleController {
         // 데이터를 view로 보냄
         map.addAttribute("articles", articles);
         map.addAttribute("paginationBarNumbers", barNumbers);
+        map.addAttribute("searchTypes", SearchType.values());
 
         return "articles/index"; // "articles/index"를 반환(컨트롤러가 렌더링할 뷰의 이름)
     }

--- a/src/main/java/com/fastcampus/mvcboardproject/domain/type/SearchType.java
+++ b/src/main/java/com/fastcampus/mvcboardproject/domain/type/SearchType.java
@@ -1,5 +1,18 @@
 package com.fastcampus.mvcboardproject.domain.type;
 
+import lombok.Getter;
+
 public enum SearchType {
-    TITLE, CONTENT, ID, NICKNAME, HASHTAG
+    TITLE("제목"),
+    CONTENT("본문"),
+    ID("유저 ID"),
+    NICKNAME("닉네임"),
+    HASHTAG("해시태그");
+
+    @Getter
+    private final String description;
+
+    SearchType(String description) {
+        this.description = description;
+    }
 }

--- a/src/main/java/com/fastcampus/mvcboardproject/repository/ArticleRepository.java
+++ b/src/main/java/com/fastcampus/mvcboardproject/repository/ArticleRepository.java
@@ -1,6 +1,7 @@
 package com.fastcampus.mvcboardproject.repository;
 
 import com.fastcampus.mvcboardproject.domain.Article;
+import com.fastcampus.mvcboardproject.repository.querydsl.ArticleRepositoryCustom;
 import com.querydsl.core.types.dsl.DateTimeExpression;
 import com.querydsl.core.types.dsl.StringExpression;
 import com.fastcampus.mvcboardproject.domain.QArticle;
@@ -15,6 +16,7 @@ import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 @RepositoryRestResource
 public interface ArticleRepository extends
         JpaRepository<Article, Long>,
+        ArticleRepositoryCustom,
         QuerydslPredicateExecutor<Article>,
         QuerydslBinderCustomizer<QArticle> {
 

--- a/src/main/java/com/fastcampus/mvcboardproject/repository/querydsl/ArticleRepositoryCustom.java
+++ b/src/main/java/com/fastcampus/mvcboardproject/repository/querydsl/ArticleRepositoryCustom.java
@@ -1,0 +1,7 @@
+package com.fastcampus.mvcboardproject.repository.querydsl;
+
+import java.util.List;
+
+public interface ArticleRepositoryCustom {
+    List<String> findAllDistinctHashtags();
+}

--- a/src/main/java/com/fastcampus/mvcboardproject/repository/querydsl/ArticleRepositoryCustomImpl.java
+++ b/src/main/java/com/fastcampus/mvcboardproject/repository/querydsl/ArticleRepositoryCustomImpl.java
@@ -1,0 +1,28 @@
+package com.fastcampus.mvcboardproject.repository.querydsl;
+
+import com.fastcampus.mvcboardproject.domain.Article;
+import com.fastcampus.mvcboardproject.domain.QArticle;
+import com.querydsl.jpa.JPQLQuery;
+import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+public class ArticleRepositoryCustomImpl extends QuerydslRepositorySupport implements ArticleRepositoryCustom {
+
+    public ArticleRepositoryCustomImpl() {
+        super(Article.class);
+    }
+
+    @Override
+    public List<String> findAllDistinctHashtags() {
+        QArticle article = QArticle.article;
+
+        JPQLQuery<String> query = from(article)
+                .distinct()
+                .select(article.hashtag)
+                .where(article.hashtag.isNotNull());
+
+        return query.fetch();
+    }
+}

--- a/src/main/java/com/fastcampus/mvcboardproject/service/ArticleService.java
+++ b/src/main/java/com/fastcampus/mvcboardproject/service/ArticleService.java
@@ -14,6 +14,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.List;
+
 /*
     엔티티를 노출시키지 않아야 한다.
  */
@@ -79,4 +81,28 @@ public class ArticleService {
             log.warn("존재하지 않는 게시글 입니다. - articleId: {}", articleId);
         }
     }
+
+    // 해시태그 검색(해시태그 있고 검색어가 없으면 비어 있는 페이지를 반환해야 함)
+    @Transactional(readOnly = true)
+    public Page<ArticleDto> searchArticlesViaHashtag(String hashtag, Pageable pageable) {
+        log.error("[해시태그 검색] Find Articles With Hashtag = {}", hashtag);
+
+        if (hashtag == null || hashtag.isEmpty() || hashtag.isBlank()) {
+            log.error("[해시태그 검색] Search Params is Null");
+            return Page.empty(pageable);
+        }
+
+        return articleRepository.findByHashtag(hashtag, pageable).map(ArticleDto::from);
+    }
+
+    // 유니크한 해시태그를 불러옴
+    @Transactional(readOnly = true)
+    public List<String> getHashtags() {
+        List<String> uniqueHashtags = articleRepository.findAllDistinctHashtags();
+        log.error("[유니크 해시태그 조회] uniqueHashtags = {}", uniqueHashtags);
+        System.out.println(uniqueHashtags);
+
+        return uniqueHashtags;
+    }
+
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,8 +5,8 @@ management.endpoints.web.exposure.include: "*"
 
 logging:
   level:
-    com.fastcampus.mvcboardproject: debug
-    org.springframework.web.servlet: debug
+    com.fastcampus.mvcboardproject: error
+    org.springframework.web.servlet: error
     org.hibernate.type.descriptor.sql.BasicBinder: trace
 
 spring:

--- a/src/main/resources/templates/articles/index.html
+++ b/src/main/resources/templates/articles/index.html
@@ -1,108 +1,108 @@
 <!DOCTYPE html>
 <html lang="ko">
 <head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="">
-  <meta name="author" content="Uno Kim">
-  <title>게시판 페이지</title>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="">
+    <meta name="author" content="Uno Kim">
+    <title>게시판 페이지</title>
 
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0-beta1/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-0evHe/X+R7YkIZDRvuzKMRqM+OrBnVFBL6DOitfPri4tjfHxaWutUpFmBp4vmVor" crossorigin="anonymous">
-  <link href="/css/search-bar.css" rel="stylesheet">
-  <link href="/css/articles/table-header.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0-beta1/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-0evHe/X+R7YkIZDRvuzKMRqM+OrBnVFBL6DOitfPri4tjfHxaWutUpFmBp4vmVor" crossorigin="anonymous">
+    <link href="/css/search-bar.css" rel="stylesheet">
+    <link href="/css/articles/table-header.css" rel="stylesheet">
 </head>
 
 <body>
 
-  <header id="header">
+<header id="header">
     헤더 삽입부
     <hr>
-  </header>
+</header>
 
-  <main class="container">
+<main class="container">
 
     <div class="row">
-      <div class="card card-margin search-form">
-        <div class="card-body p-0">
-          <form id="card search-form">
-            <div class="row">
-              <div class="col-12">
-                <div class="row no-gutters">
-                  <div class="col-lg-3 col-md-3 col-sm-12 p-0">
-                    <label for="search-type" hidden>검색 유형</label>
-                    <select class="form-control" id="search-type">
-                      <option>제목</option>
-                      <option>본문</option>
-                      <option>id</option>
-                      <option>닉네임</option>
-                      <option>해시태그</option>
-                    </select>
-                  </div>
-                  <div class="col-lg-8 col-md-6 col-sm-12 p-0">
-                    <label for="search-value" hidden>검색어</label>
-                    <input type="text" placeholder="검색어..." class="form-control" id="search-value" name="search-value">
-                  </div>
-                  <div class="col-lg-1 col-md-3 col-sm-12 p-0">
-                    <button type="submit" class="btn btn-base">
-                      <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-search">
-                        <circle cx="11" cy="11" r="8"></circle>
-                        <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
-                      </svg>
-                    </button>
-                  </div>
-                </div>
-              </div>
+        <div class="card card-margin search-form">
+            <div class="card-body p-0">
+                <form action="/articles" method="get">
+                    <div class="row">
+                        <div class="col-12">
+                            <div class="row no-gutters">
+                                <div class="col-lg-3 col-md-3 col-sm-12 p-0">
+                                    <label for="search-type" hidden>검색 유형</label>
+                                    <select class="form-control" id="search-type" name="searchType">
+                                        <option>테스트1</option>
+                                        <option>테스트2</option>
+                                        <option>id</option>
+                                        <option>닉네임</option>
+                                        <option>해시태그</option>
+                                    </select>
+                                </div>
+                                <div class="col-lg-8 col-md-6 col-sm-12 p-0">
+                                    <label for="search-value" hidden>검색어</label>
+                                    <input type="text" placeholder="검색어..." class="form-control" id="search-value" name="searchValue">
+                                </div>
+                                <div class="col-lg-1 col-md-3 col-sm-12 p-0">
+                                    <button type="submit" class="btn btn-base">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-search">
+                                            <circle cx="11" cy="11" r="8"></circle>
+                                            <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
+                                        </svg>
+                                    </button>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </form>
             </div>
-          </form>
         </div>
-      </div>
     </div>
 
     <table class="table" id="article-table">
-      <thead>
+        <thead>
         <tr>
-          <th class="title col-6"><a>제목</a></th>
-          <th class="hashtag col-2"><a>해시태그</a></th>
-          <th class="user-id col"><a>작성자</a></th>
-          <th class="created-at col"><a>작성일</a></th>
+            <th class="title col-6"><a>제목</a></th>
+            <th class="hashtag col-2"><a>해시태그</a></th>
+            <th class="user-id col"><a>작성자</a></th>
+            <th class="created-at col"><a>작성일</a></th>
         </tr>
-      </thead>
-      <tbody>
+        </thead>
+        <tbody>
         <tr>
-          <td class="title"><a>첫글</a></td>
-          <td class="hashtag">#java</td>
-          <td class="user-id">Uno</td>
-          <td class="created-at"><time>2022-01-01</time></td>
-        </tr>
-        <tr>
-          <td>두번째글</td>
-          <td>#spring</td>
-          <td>Uno</td>
-          <td><time>2022-01-02</time></td>
+            <td class="title"><a>첫글</a></td>
+            <td class="hashtag">#java</td>
+            <td class="user-id">Uno</td>
+            <td class="created-at"><time>2022-01-01</time></td>
         </tr>
         <tr>
-          <td>세번째글</td>
-          <td>#java</td>
-          <td>Uno</td>
-          <td><time>2022-01-03</time></td>
+            <td>두번째글</td>
+            <td>#spring</td>
+            <td>Uno</td>
+            <td><time>2022-01-02</time></td>
         </tr>
-      </tbody>
+        <tr>
+            <td>세번째글</td>
+            <td>#java</td>
+            <td>Uno</td>
+            <td><time>2022-01-03</time></td>
+        </tr>
+        </tbody>
     </table>
 
-    <nav id="pagination" aria-label="Page navigation example">
-      <ul class="pagination justify-content-center">
-        <li class="page-item"><a class="page-link" href="#">Previous</a></li>
-        <li class="page-item"><a class="page-link" href="#">1</a></li>
-        <li class="page-item"><a class="page-link" href="#">Next</a></li>
-      </ul>
+    <nav id="pagination" aria-label="Page navigation">
+        <ul class="pagination justify-content-center">
+            <li class="page-item"><a class="page-link" href="#">Previous</a></li>
+            <li class="page-item"><a class="page-link" href="#">1</a></li>
+            <li class="page-item"><a class="page-link" href="#">Next</a></li>
+        </ul>
     </nav>
-  </main>
+</main>
 
-  <footer id="footer">
+<footer id="footer">
     <hr>
     푸터 삽입부
-  </footer>
+</footer>
 
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0-beta1/dist/js/bootstrap.bundle.min.js" integrity="sha384-pprn3073KE6tl6bjs2QrFaJGz5/SUsLqktiwsUTF55Jfv3qYSDhgCecCxMW52nD2" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0-beta1/dist/js/bootstrap.bundle.min.js" integrity="sha384-pprn3073KE6tl6bjs2QrFaJGz5/SUsLqktiwsUTF55Jfv3qYSDhgCecCxMW52nD2" crossorigin="anonymous"></script>
 </body>
 </html>

--- a/src/main/resources/templates/articles/index.th.xml
+++ b/src/main/resources/templates/articles/index.th.xml
@@ -4,24 +4,41 @@
   <attr sel="#footer" th:replace="footer :: footer" />
 
   <attr sel="main" th:object="${articles}">
+    <attr sel="#search-type" th:remove="all-but-first">
+      <attr sel="option[0]"
+            th:each="searchType : ${searchTypes}"
+            th:value="${searchType.name}"
+            th:text="${searchType.description}"
+            th:selected="${param.searchType != null && (param.searchType.toString == searchType.name)}"
+      />
+    </attr>
+    <attr sel="#search-value" th:value="${param.searchValue}" />
 
     <attr sel="#article-table">
       <attr sel="thead/tr">
         <attr sel="th.title/a" th:text="'제목'" th:href="@{/articles(
             page=${articles.number},
-            sort='title' + (*{sort.getOrderFor('title')} != null ? (*{sort.getOrderFor('title').direction.name} != 'DESC' ? ',desc' : '') : '')
+            sort='title' + (*{sort.getOrderFor('title')} != null ? (*{sort.getOrderFor('title').direction.name} != 'DESC' ? ',desc' : '') : ''),
+            searchType=${param.searchType},
+            searchValue=${param.searchValue}
         )}"/>
         <attr sel="th.hashtag/a" th:text="'해시태그'" th:href="@{/articles(
             page=${articles.number},
-            sort='hashtag' + (*{sort.getOrderFor('hashtag')} != null ? (*{sort.getOrderFor('hashtag').direction.name} != 'DESC' ? ',desc' : '') : '')
+            sort='hashtag' + (*{sort.getOrderFor('hashtag')} != null ? (*{sort.getOrderFor('hashtag').direction.name} != 'DESC' ? ',desc' : '') : ''),
+            searchType=${param.searchType},
+            searchValue=${param.searchValue}
         )}"/>
         <attr sel="th.user-id/a" th:text="'작성자'" th:href="@{/articles(
             page=${articles.number},
-            sort='userAccount.userId' + (*{sort.getOrderFor('userAccount.userId')} != null ? (*{sort.getOrderFor('userAccount.userId').direction.name} != 'DESC' ? ',desc' : '') : '')
+            sort='userAccount.userId' + (*{sort.getOrderFor('userAccount.userId')} != null ? (*{sort.getOrderFor('userAccount.userId').direction.name} != 'DESC' ? ',desc' : '') : ''),
+            searchType=${param.searchType},
+            searchValue=${param.searchValue}
         )}"/>
         <attr sel="th.created-at/a" th:text="'작성일'" th:href="@{/articles(
             page=${articles.number},
-            sort='createdAt' + (*{sort.getOrderFor('createdAt')} != null ? (*{sort.getOrderFor('createdAt').direction.name} != 'DESC' ? ',desc' : '') : '')
+            sort='createdAt' + (*{sort.getOrderFor('createdAt')} != null ? (*{sort.getOrderFor('createdAt').direction.name} != 'DESC' ? ',desc' : '') : ''),
+            searchType=${param.searchType},
+            searchValue=${param.searchValue}
         )}"/>
       </attr>
 
@@ -34,25 +51,25 @@
         </attr>
       </attr>
     </attr>
-
     <attr sel="#pagination">
       <attr sel="li[0]/a"
             th:text="'previous'"
-            th:href="@{/articles(page=${articles.number - 1})}"
+            th:href="@{/articles(page=${articles.number - 1}, searchType=${param.searchType}, searchValue=${param.searchValue})}"
             th:class="'page-link' + (${articles.number} <= 0 ? ' disabled' : '')"
       />
       <attr sel="li[1]" th:class="page-item" th:each="pageNumber : ${paginationBarNumbers}">
         <attr sel="a"
               th:text="${pageNumber + 1}"
-              th:href="@{/articles(page=${pageNumber})}"
+              th:href="@{/articles(page=${pageNumber}, searchType=${param.searchType}, searchValue=${param.searchValue})}"
               th:class="'page-link' + (${pageNumber} == ${articles.number} ? ' disabled' : '')"
         />
       </attr>
       <attr sel="li[2]/a"
             th:text="'next'"
-            th:href="@{/articles(page=${articles.number + 1})}"
+            th:href="@{/articles(page=${articles.number + 1}, searchType=${param.searchType}, searchValue=${param.searchValue})}"
             th:class="'page-link' + (${articles.number} >= ${articles.totalPages - 1} ? ' disabled' : '')"
       />
     </attr>
   </attr>
 </thlogic>
+

--- a/src/main/resources/templates/articles/search-hashtag.html
+++ b/src/main/resources/templates/articles/search-hashtag.html
@@ -1,10 +1,83 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="ko">
 <head>
   <meta charset="UTF-8">
-  <title>Articles</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="">
+  <meta name="author" content="Uno Kim">
+  <title>해시태그 검색</title>
+
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0-beta1/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-0evHe/X+R7YkIZDRvuzKMRqM+OrBnVFBL6DOitfPri4tjfHxaWutUpFmBp4vmVor" crossorigin="anonymous">
+  <link href="/css/articles/table-header.css" rel="stylesheet">
 </head>
+
 <body>
-게시글 해시태그 검색
+<header id="header">
+  헤더 삽입부
+  <hr>
+</header>
+
+<main class="container">
+  <header class="py-5 text-center">
+    <h1>Hashtags</h1>
+  </header>
+
+  <section class="row">
+    <div id="hashtags" class="col-9 d-flex flex-wrap justify-content-evenly">
+      <div class="p-2">
+        <h2 class="text-center lh-lg font-monospace"><a href="#">#java</a></h2>
+      </div>
+    </div>
+  </section>
+
+  <hr>
+
+  <table class="table" id="article-table">
+    <thead>
+    <tr>
+      <th class="title col-6"><a>제목</a></th>
+      <th class="content col-4"><a>본문</a></th>
+      <th class="user-id"><a>작성자</a></th>
+      <th class="created-at"><a>작성일</a></th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr>
+      <td class="title"><a>첫글</a></td>
+      <td class="content"><span class="d-inline-block text-truncate" style="max-width: 300px;">본문</span></td>
+      <td class="user-id">Uno</td>
+      <td class="created-at"><time>2022-01-01</time></td>
+    </tr>
+    <tr>
+      <td>두번째글</td>
+      <td>본문</td>
+      <td>Uno</td>
+      <td><time>2022-01-02</time></td>
+    </tr>
+    <tr>
+      <td>세번째글</td>
+      <td>본문</td>
+      <td>Uno</td>
+      <td><time>2022-01-03</time></td>
+    </tr>
+    </tbody>
+  </table>
+
+  <nav id="pagination" aria-label="Page navigation">
+    <ul class="pagination justify-content-center">
+      <li class="page-item"><a class="page-link" href="#">Previous</a></li>
+      <li class="page-item"><a class="page-link" href="#">1</a></li>
+      <li class="page-item"><a class="page-link" href="#">Next</a></li>
+    </ul>
+  </nav>
+
+</main>
+
+<footer id="footer">
+  <hr>
+  푸터 삽입부
+</footer>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0-beta1/dist/js/bootstrap.bundle.min.js" integrity="sha384-pprn3073KE6tl6bjs2QrFaJGz5/SUsLqktiwsUTF55Jfv3qYSDhgCecCxMW52nD2" crossorigin="anonymous"></script>
 </body>
 </html>

--- a/src/main/resources/templates/articles/search-hashtag.th.xml
+++ b/src/main/resources/templates/articles/search-hashtag.th.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0"?>
+<thlogic>
+    <attr sel="#header" th:replace="header :: header" />
+    <attr sel="#footer" th:replace="footer :: footer" />
+
+    <attr sel="main" th:object="${articles}">
+        <attr sel="#hashtags" th:remove="all-but-first">
+            <attr sel="div" th:each="hashtag : ${hashtags}">
+                <attr sel="a" th:class="'text-reset'" th:text="${hashtag}" th:href="@{/articles/search-hashtag(
+            page=${param.page},
+            sort=${param.sort},
+            searchType=${searchType.name},
+            searchValue=${hashtag}
+        )}" />
+            </attr>
+        </attr>
+
+        <attr sel="#article-table">
+            <attr sel="thead/tr">
+                <attr sel="th.title/a" th:text="'제목'" th:href="@{/articles/search-hashtag(
+            page=${articles.number},
+            sort='title' + (*{sort.getOrderFor('title')} != null ? (*{sort.getOrderFor('title').direction.name} != 'DESC' ? ',desc' : '') : ''),
+            searchType=${searchType.name},
+            searchValue=${param.searchValue}
+        )}"/>
+                <attr sel="th.content/a" th:text="'본문'" th:href="@{/articles/search-hashtag(
+            page=${articles.number},
+            sort='content' + (*{sort.getOrderFor('content')} != null ? (*{sort.getOrderFor('content').direction.name} != 'DESC' ? ',desc' : '') : ''),
+            searchType=${searchType.name},
+            searchValue=${param.searchValue}
+        )}"/>
+                <attr sel="th.user-id/a" th:text="'작성자'" th:href="@{/articles/search-hashtag(
+            page=${articles.number},
+            sort='userAccount.userId' + (*{sort.getOrderFor('userAccount.userId')} != null ? (*{sort.getOrderFor('userAccount.userId').direction.name} != 'DESC' ? ',desc' : '') : ''),
+            searchType=${searchType.name},
+            searchValue=${param.searchValue}
+        )}"/>
+                <attr sel="th.created-at/a" th:text="'작성일'" th:href="@{/articles/search-hashtag(
+            page=${articles.number},
+            sort='createdAt' + (*{sort.getOrderFor('createdAt')} != null ? (*{sort.getOrderFor('createdAt').direction.name} != 'DESC' ? ',desc' : '') : ''),
+            searchType=${searchType.name},
+            searchValue=${param.searchValue}
+        )}"/>
+            </attr>
+            <attr sel="tbody" th:remove="all-but-first">
+                <attr sel="tr[0]" th:each="article : ${articles}">
+                    <attr sel="td.title/a" th:text="${article.title}" th:href="@{'/articles/' + ${article.id}}" />
+                    <attr sel="td.content/span" th:text="${article.content}" />
+                    <attr sel="td.user-id" th:text="${article.nickname}" />
+                    <attr sel="td.created-at/time" th:datetime="${article.createdAt}" th:text="${#temporals.format(article.createdAt, 'yyyy-MM-dd')}" />
+                </attr>
+            </attr>
+        </attr>
+
+        <attr sel="#pagination">
+            <attr sel="ul">
+                <attr sel="li[0]/a"
+                      th:text="'previous'"
+                      th:href="@{/articles(page=${articles.number - 1}, searchType=${searchType.name}, searchValue=${param.searchValue})}"
+                      th:class="'page-link' + (${articles.number} <= 0 ? ' disabled' : '')"
+                />
+                <attr sel="li[1]" th:class="page-item" th:each="pageNumber : ${paginationBarNumbers}">
+                    <attr sel="a"
+                          th:text="${pageNumber + 1}"
+                          th:href="@{/articles(page=${pageNumber}, searchType=${searchType.name}, searchValue=${param.searchValue})}"
+                          th:class="'page-link' + (${pageNumber} == ${articles.number} ? ' disabled' : '')"
+                    />
+                </attr>
+                <attr sel="li[2]/a"
+                      th:text="'next'"
+                      th:href="@{/articles(page=${articles.number + 1}, searchType=${searchType.name}, searchValue=${param.searchValue})}"
+                      th:class="'page-link' + (${articles.number} >= ${articles.totalPages - 1} ? ' disabled' : '')"
+                />
+            </attr>
+        </attr>
+    </attr>
+</thlogic>

--- a/src/main/resources/templates/footer.html
+++ b/src/main/resources/templates/footer.html
@@ -7,7 +7,7 @@
 
 <body>
   <footer class="container d-flex flex-wrap justify-content-between align-items-center py-3 my-4 border-top">
-    <p class="col-md-4 mb-0 text-muted">&copy; 2022 FastCampus, Inc</p>
+    <p class="col-md-4 mb-0 text-muted">&copy; 2024 LeticiaCompany, Inc</p>
 
     <ul class="nav col-md-4 justify-content-end">
       <li class="nav-item"><a href="/" class="nav-link px-2 text-muted">Home</a></li>

--- a/src/test/java/com/fastcampus/mvcboardproject/controller/ArticleControllerTest.java
+++ b/src/test/java/com/fastcampus/mvcboardproject/controller/ArticleControllerTest.java
@@ -1,6 +1,7 @@
 package com.fastcampus.mvcboardproject.controller;
 
 import com.fastcampus.mvcboardproject.config.SecurityConfig;
+import com.fastcampus.mvcboardproject.domain.type.SearchType;
 import com.fastcampus.mvcboardproject.dto.ArticleWithCommentsDto;
 import com.fastcampus.mvcboardproject.dto.UserAccountDto;
 import com.fastcampus.mvcboardproject.service.ArticleService;
@@ -49,7 +50,7 @@ class ArticleControllerTest {
 //    @Disabled("구현 중")
     @DisplayName("[뷰][GET]게시판 목록(게시판) 조회 페이지")
     @Test
-    public void GivenNothing_WhenRequestArticlesView_ThenReturnsArticlesView() throws Exception {
+    public void givenNothing_whenRequestingArticlesView_thenReturnsArticlesView() throws Exception {
         //Given
         // 검색어 없는 경우,
         given(articleService.searchArticles(eq(null), eq(null), any(Pageable.class))).willReturn(Page.empty());
@@ -64,12 +65,38 @@ class ArticleControllerTest {
                 .andExpect(model().attributeExists("articles"))
                 .andExpect(model().attributeExists("paginationBarNumbers"));
 
+        then(articleService).should().searchArticles(eq(null), eq(null), any(Pageable.class));
+        then(paginationService).should().getPaginationBarNumbers(anyInt(), anyInt());
+    }
+
+    @DisplayName("[view][GET] 게시글 리스트 (게시판) 페이지 - 검색어와 함께 호출")
+    @Test
+    public void givenSearchKeyword_whenSearchingArticlesView_thenReturnsArticlesView() throws Exception {
+        // Given
+        SearchType searchType = SearchType.TITLE;
+        String searchValue = "title";
+        given(articleService.searchArticles(eq(searchType), eq(searchValue), any(Pageable.class))).willReturn(Page.empty());
+        given(paginationService.getPaginationBarNumbers(anyInt(), anyInt())).willReturn(List.of(0, 1, 2, 3, 4));
+
+        // When & Then
+        mvc.perform(
+                        get("/articles")
+                                .queryParam("searchType", searchType.name())
+                                .queryParam("searchValue", searchValue)
+                )
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
+                .andExpect(view().name("articles/index"))
+                .andExpect(model().attributeExists("articles"))
+                .andExpect(model().attributeExists("searchTypes"));
+
+        then(articleService).should().searchArticles(eq(searchType), eq(searchValue), any(Pageable.class));
         then(paginationService).should().getPaginationBarNumbers(anyInt(), anyInt());
     }
 
     @DisplayName("[뷰][GET] 게시글 리스트 (게시판) 페이지 - 페이징, 정렬 기능")
     @Test
-    void givenPagingAndSortingParams_whenSearchingArticlesPage_thenReturnsArticlesPage() throws Exception {
+    void givenPagingAndSortingParams_whenSearchingArticlesView_thenReturnsArticlesView() throws Exception {
         // Given
         String sortName = "title";
         String direction = "desc";
@@ -103,7 +130,7 @@ class ArticleControllerTest {
 //    @Disabled("구현 중")
     @DisplayName("[뷰][GET]게시글 단건 조회(N번 게시글) 페이지")
     @Test
-    public void GivenNothing_WhenRequestSpecificArticleView_ThenReturnsSpecificArticleView() throws Exception {
+    public void givenNothing_whenRequestingArticleView_thenReturnsArticleView() throws Exception {
         //Given
         Long articleId = 1L;
         given(articleService.getArticle(articleId)).willReturn(createArticleWithCommentsDto());

--- a/src/test/java/com/fastcampus/mvcboardproject/controller/AuthControllerTest.java
+++ b/src/test/java/com/fastcampus/mvcboardproject/controller/AuthControllerTest.java
@@ -15,7 +15,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @DisplayName("View 컨트롤러 - 인증")
 @Import(SecurityConfig.class)
-@WebMvcTest
+@WebMvcTest(MainController.class)
 public class AuthControllerTest {
 
     private final MockMvc mvc;


### PR DESCRIPTION
- 해시태그를 통하 검색 기능 테스트를 작성하고,
- 테스트를 기반으로 기능을 구현함

- 전체 게시글의 해시태그를 보여주는 페이지를 만들었음(articles/search-hashtag)
- 이를 위해 커스텀한 querydsl을 만들어 적용함.