### PR TITLE
게시글 검색(제목, 본문, 해시태그, 작성자) 기능 및 해시태그 검색 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
     // queryDSL 설정
-    implementation "com.querydsl:querydsl-jpa"
+    implementation "com.querydsl:querydsl-jpa:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
     implementation "com.querydsl:querydsl-core"
     implementation "com.querydsl:querydsl-collections"
     annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta" // querydsl JPAAnnotationProcessor 사용 지정

--- a/src/main/java/com/fastcampus/mvcboardproject/controller/ArticleController.java
+++ b/src/main/java/com/fastcampus/mvcboardproject/controller/ArticleController.java
@@ -72,18 +72,10 @@ public class ArticleController {
             @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
             ModelMap map
     ) {
-        log.error("[컨트롤러] search-hashtag 확인, searchValue: {}", searchValue);
 
         Page<ArticleResponse> articles = articleService.searchArticlesViaHashtag(searchValue, pageable).map(ArticleResponse::from);
-        log.error("[컨트롤러] searchArticlesViaHashtag에서 패스");
-        
         List<Integer> barNumbers = paginationService.getPaginationBarNumbers(pageable.getPageNumber(), articles.getTotalPages());
-        log.error("[컨트롤러] getPaginationBarNumbers에서 패스");
-        
         List<String> hashtags = articleService.getHashtags();
-        log.error("[컨트롤러] getHashtags에서 패스");
-
-        log.error("[컨트롤러] articles: {}, barNumbers: {}, hashtag: {}", articles, barNumbers, hashtags);
 
         map.addAttribute("articles", articles);
         map.addAttribute("hashtags", hashtags);

--- a/src/main/java/com/fastcampus/mvcboardproject/service/ArticleService.java
+++ b/src/main/java/com/fastcampus/mvcboardproject/service/ArticleService.java
@@ -70,7 +70,6 @@ public class ArticleService {
             // 해시태그는 null 가능 필드임
             article.setHashtag(dto.hashtag());
         } catch (EntityNotFoundException e) {
-            log.warn("게시글 업데이트 실패. 게시글을 찾을 수 없습니다 - dto: {}", dto);
         }
     }
 
@@ -78,17 +77,14 @@ public class ArticleService {
         try{
             articleRepository.deleteById(articleId);
         }catch (EntityNotFoundException e){
-            log.warn("존재하지 않는 게시글 입니다. - articleId: {}", articleId);
         }
     }
 
     // 해시태그 검색(해시태그 있고 검색어가 없으면 비어 있는 페이지를 반환해야 함)
     @Transactional(readOnly = true)
     public Page<ArticleDto> searchArticlesViaHashtag(String hashtag, Pageable pageable) {
-        log.error("[해시태그 검색] Find Articles With Hashtag = {}", hashtag);
 
         if (hashtag == null || hashtag.isEmpty() || hashtag.isBlank()) {
-            log.error("[해시태그 검색] Search Params is Null");
             return Page.empty(pageable);
         }
 
@@ -99,8 +95,6 @@ public class ArticleService {
     @Transactional(readOnly = true)
     public List<String> getHashtags() {
         List<String> uniqueHashtags = articleRepository.findAllDistinctHashtags();
-        log.error("[유니크 해시태그 조회] uniqueHashtags = {}", uniqueHashtags);
-        System.out.println(uniqueHashtags);
 
         return uniqueHashtags;
     }

--- a/src/main/resources/templates/header.html
+++ b/src/main/resources/templates/header.html
@@ -10,6 +10,7 @@
       <div class="d-flex flex-wrap align-items-center justify-content-center justify-content-lg-start">
         <ul class="nav col-12 col-lg-auto me-lg-auto mb-2 justify-content-center mb-md-0">
           <li><a href="/" class="nav-link px-2 text-secondary">Home</a></li>
+          <li><a href="/articles/search-hashtag" class="nav-link px-2 text-secondary">Hashtag</a></li>
         </ul>
 
         <div class="text-end">


### PR DESCRIPTION
- 검색바 기능 구현
- searchType에 대한 descriptipon 필드 추가 (뷰에 표현하기 위해서)
- 관련 테스트 추가
- 검색바 기능 연동
- 페이징바, 정렬 기능에 검색 타입에 대한 값 추가
- 전체 게시글의 해시태그 반환 테스트 로직 추가
- 해시태그 검색 기능 테스트 로직 추가
- 관련 기능 서비스 로직 뼈대 구축
- 전체 해시태그 목록 반환 repository 구성 및 구현
- 해시태그 검색 관련 기능 서비스 연동
- 관련 기능 테스트를 위한 service 테스트 로직 추가
- 해시태그 검색 페이지 controller api 추가
- 해시태그 검색 관련 서비스와 컨트롤러 연동
- 해시태그 검색 페이지 관련 컨트롤러 테스트 추가
- 해시태그 검색 페이지 임시 페이지 생성
- hashtags는 보유하는 모든 해시태그 list
- controller 레벨에 추가 및 관련 테스트 코드 수정
- 해시태그 검색 페이지 뷰 적용