### PR TITLE
Spring Security Config 및 JpaConfig 설정

### DIFF
--- a/src/main/java/com/fastcampus/mvcboardproject/config/JpaConfig.java
+++ b/src/main/java/com/fastcampus/mvcboardproject/config/JpaConfig.java
@@ -1,9 +1,13 @@
 package com.fastcampus.mvcboardproject.config;
 
+import com.fastcampus.mvcboardproject.dto.security.BoardPrincipal;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.domain.AuditorAware;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
 
 import java.util.Optional;
 
@@ -12,9 +16,13 @@ import java.util.Optional;
 public class JpaConfig {
 
     @Bean
-    // 생성자를 자동으로 넣기 위함
     public AuditorAware<String> auditorAware(){
-        return () -> Optional.of("테스터_작성자");
-        //TODO: 스프린 시큐리티로 인증 기능을 붙이게 될 때, 수정하기
+        return () -> Optional.ofNullable(SecurityContextHolder.getContext())
+                .map(SecurityContext::getAuthentication)
+                .filter(Authentication::isAuthenticated)  // 로그인한 상태인지 확인
+                .map(Authentication::getPrincipal)  // getPrincipal : return Object
+                .map(BoardPrincipal.class::cast)    // Type Casting
+                .map(BoardPrincipal::getUsername);
     }
+
 }

--- a/src/main/java/com/fastcampus/mvcboardproject/config/SecurityConfig.java
+++ b/src/main/java/com/fastcampus/mvcboardproject/config/SecurityConfig.java
@@ -32,6 +32,7 @@ public class SecurityConfig {
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
             .authorizeHttpRequests((auth) -> auth
+                    .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
                     .requestMatchers(HttpMethod.GET, "/", "/articles", "/articles/search-hashtag").permitAll()
                     .anyRequest().authenticated()
             )
@@ -43,13 +44,6 @@ public class SecurityConfig {
                     logout -> logout
                             .logoutSuccessUrl("/"));
         return http.build();
-    }
-
-    @Bean
-    public WebSecurityCustomizer webSecurityCustomizer() {
-        return web -> {
-            web.ignoring().requestMatchers(PathRequest.toStaticResources().atCommonLocations());
-        };
     }
 
     /*

--- a/src/main/java/com/fastcampus/mvcboardproject/config/SecurityConfig.java
+++ b/src/main/java/com/fastcampus/mvcboardproject/config/SecurityConfig.java
@@ -1,21 +1,78 @@
 package com.fastcampus.mvcboardproject.config;
 
+import com.fastcampus.mvcboardproject.dto.UserAccountDto;
+import com.fastcampus.mvcboardproject.dto.security.BoardPrincipal;
+import com.fastcampus.mvcboardproject.repository.UserAccountRepository;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
-
-import static org.springframework.security.config.Customizer.withDefaults;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 
 @Configuration
 public class SecurityConfig {
 
+    /*
+        HTTP를 통한 인증과 인가를 담당하는 메서드이다.
+     */
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-        return http
-                .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
-                .formLogin(withDefaults())  ///login 엔드포인트를 생성하여 로그인 페이지로 이동
-                .build();
+        http
+            .authorizeHttpRequests((auth) -> auth
+                    .requestMatchers(HttpMethod.GET, "/", "/articles", "/articles/search-hashtag").permitAll()
+                    .anyRequest().authenticated()
+            )
+            .formLogin(
+                    form -> form
+                            .loginPage("/login")
+                            .loginProcessingUrl("/users"))
+            .logout(
+                    logout -> logout
+                            .logoutSuccessUrl("/"));
+        return http.build();
+    }
+
+    @Bean
+    public WebSecurityCustomizer webSecurityCustomizer() {
+        return web -> {
+            web.ignoring().requestMatchers(PathRequest.toStaticResources().atCommonLocations());
+        };
+    }
+
+    /*
+        loadUserByUsername을 람다식으로 구현하였으면,
+        입력값은 userAccountRepository이고
+        반환값은 BoardPrincipal이다.
+        userName을 찾을 수 없는 경우, NotFoundException 예외가 발생한다.
+     */
+    @Bean
+    public UserDetailsService userDetailsService(UserAccountRepository userAccountRepository) {
+        return username -> userAccountRepository
+                .findById(username)            // User 객체를 가여좀
+                .map(UserAccountDto::from)     // User 객체를 UserAccountDto로 변환함(작성, 수정 정보는 null)
+                .map(BoardPrincipal::from)     // 권한이 추가되어 BoardPrincipal객체로 변환
+                .orElseThrow(() -> new UsernameNotFoundException("유저를 찾을 수 없습니다 - username: " + username));
+    }
+
+    /*
+        spring security의 인증기능을 구현할 때, 비밀번호 암호화를 위해 반드시 설정해야 한다.
+     */
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return PasswordEncoderFactories.createDelegatingPasswordEncoder();
     }
 
 }

--- a/src/main/java/com/fastcampus/mvcboardproject/dto/security/BoardPrincipal.java
+++ b/src/main/java/com/fastcampus/mvcboardproject/dto/security/BoardPrincipal.java
@@ -1,0 +1,94 @@
+package com.fastcampus.mvcboardproject.dto.security;
+
+import com.fastcampus.mvcboardproject.dto.UserAccountDto;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public record BoardPrincipal(
+        String username,
+        String password,
+        Collection<? extends GrantedAuthority> authorities,  //계정이 가지고 있는 권한 목록
+        String email,
+        String nickname,
+        String memo
+) implements UserDetails {
+
+    /*
+        (이름, 비밀번호, 이메일, 닉네임, 메모)에 대한 매개변수를 입력하면
+        RoleType에서 USER값을 defaulf 넣어, BoardPrincipal 객체로 반환한다.
+        BoardPrincipal 객체는 (이름, 비밀번호, 권한정보, 이메일, 닉네임, 메모)를 가지고 있다.
+     */
+    public static BoardPrincipal of(String username, String password, String email, String nickname, String memo) {
+        Set<RoleType> roleTypes = Set.of(RoleType.USER);
+
+        return new BoardPrincipal(
+                username,
+                password,
+                roleTypes.stream()
+                        .map(RoleType::getName)   // USER
+                        .map(SimpleGrantedAuthority::new)     // SimpleGrantedAuthority("USER")
+                        .collect(Collectors.toUnmodifiableSet())      // 수정이 불가한 SET으로 변환
+                ,
+                email,
+                nickname,
+                memo
+        );
+    }
+
+    public static BoardPrincipal from(UserAccountDto dto) {   //유저 DTO를 넣어주면, 권한 정보를 set타입으로 바꿔서 반환해준다.
+        return BoardPrincipal.of(
+                dto.userId(),
+                dto.userPassword(),
+                dto.email(),
+                dto.nickname(),
+                dto.memo()
+        );
+    }
+
+    public UserAccountDto toDto() {
+        return UserAccountDto.of(
+                username,
+                password,
+                email,
+                nickname,
+                memo
+        );
+    }
+
+
+    @Override public String getUsername() {
+        return username;
+    }
+
+    @Override public String getPassword() {
+        return password;
+    }
+
+    @Override public Collection<? extends GrantedAuthority> getAuthorities() {
+        return authorities;
+    }  //권한에 대한 정보
+
+    @Override public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override public boolean isEnabled() {
+        return true;
+    }
+
+
+}

--- a/src/main/java/com/fastcampus/mvcboardproject/dto/security/RoleType.java
+++ b/src/main/java/com/fastcampus/mvcboardproject/dto/security/RoleType.java
@@ -1,0 +1,14 @@
+package com.fastcampus.mvcboardproject.dto.security;
+
+import lombok.Getter;
+
+public enum RoleType {
+    USER("ROLE_USER");
+
+    @Getter
+    private final String name;
+
+    RoleType(String name) {
+        this.name = name;
+    }
+}

--- a/src/test/java/com/fastcampus/mvcboardproject/config/TestSecurityConfig.java
+++ b/src/test/java/com/fastcampus/mvcboardproject/config/TestSecurityConfig.java
@@ -1,0 +1,36 @@
+package com.fastcampus.mvcboardproject.config;
+
+import com.fastcampus.mvcboardproject.domain.UserAccount;
+import com.fastcampus.mvcboardproject.repository.UserAccountRepository;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.event.annotation.BeforeTestMethod;
+
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+
+/*
+    테스트 전용 Security Config
+ */
+@Import(SecurityConfig.class)
+public class TestSecurityConfig {
+
+    @MockBean private UserAccountRepository userAccountRepository;
+
+    /*
+        테스트용 유저 계정을 만들어,테스트에서 사용한다.
+        @BeforeTestMethod : spring boot 메서드 test를 하기 전에 해당 메서드를 실행
+     */
+    @BeforeTestMethod
+    public void securitySetUp() {
+        given(userAccountRepository.findById(anyString())).willReturn(Optional.of(UserAccount.of(
+                        "unoTest",
+                        "pw",
+                        "uno-test@email.com",
+                        "uno-test",
+                        "test memo")));
+    }
+
+}

--- a/src/test/java/com/fastcampus/mvcboardproject/repository/JpaRepositoryTest.java
+++ b/src/test/java/com/fastcampus/mvcboardproject/repository/JpaRepositoryTest.java
@@ -7,12 +7,18 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import java.util.List;
+import java.util.Optional;
 
 @DisplayName("JPA 연결 테스트")
-@Import(JpaConfig.class)
+@Import(JpaRepositoryTest.TestJpaConfig.class)
 @DataJpaTest
 class JpaRepositoryTest {
 
@@ -88,6 +94,15 @@ class JpaRepositoryTest {
         // Then
         assertThat(articleRepository.count()).isEqualTo(previousArticleCount - 1);
         assertThat(articleCommentRepository.count()).isEqualTo(previousArticleCommentCount - deletedCommentsSize);
+    }
+
+    @EnableJpaAuditing
+    @TestConfiguration
+    public static class TestJpaConfig {
+        @Bean
+        public AuditorAware<String> auditorAware() {
+            return () -> Optional.of("uno");
+        }
     }
 
 }


### PR DESCRIPTION
스프링 시큐리티에 대한 설정을 하였다.
Role을 enum으로 만들어, 
userDetails에서 유저정보와 함께 권한 정보를 넣어 인증을 확인할 수 있는 princial을 만들었다.

데이터 변경시 Auditing 감지를 하는 JpaConfig에 인증 여부에 대한 로직을 추가하였으며,
관련된 테스트에 변경사항을 반영해 통과하도록 했다.