### PR TITLE
인증기능 적용하여 테스트 및 구현 완료

### DIFF
--- a/src/main/java/com/fastcampus/mvcboardproject/controller/ArticleCommentController.java
+++ b/src/main/java/com/fastcampus/mvcboardproject/controller/ArticleCommentController.java
@@ -2,8 +2,11 @@ package com.fastcampus.mvcboardproject.controller;
 
 import com.fastcampus.mvcboardproject.dto.UserAccountDto;
 import com.fastcampus.mvcboardproject.dto.request.ArticleCommentRequest;
+import com.fastcampus.mvcboardproject.dto.request.ArticleRequest;
+import com.fastcampus.mvcboardproject.dto.security.BoardPrincipal;
 import com.fastcampus.mvcboardproject.service.ArticleCommentService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -17,19 +20,22 @@ public class ArticleCommentController {
     private final ArticleCommentService articleCommentService;
 
     @PostMapping ("/new")
-    public String postNewArticleComment(ArticleCommentRequest articleCommentRequest) {
-        // TODO: 인증 정보를 넣어줘야 한다.
-        articleCommentService.saveArticleComment(articleCommentRequest.toDto(UserAccountDto.of(
-                "uno", "pw", "uno@mail.com", null, null
-        )));
+    public String postNewArticleComment(
+            @AuthenticationPrincipal BoardPrincipal boardPrincipal,
+            ArticleCommentRequest articleCommentRequest
+    ) {
+        articleCommentService.saveArticleComment(articleCommentRequest.toDto(boardPrincipal.toDto()));
 
         return "redirect:/articles/" + articleCommentRequest.articleId();
     }
 
     @PostMapping ("/{commentId}/delete")
-    public String deleteArticleComment(@PathVariable Long commentId, Long articleId) {
-        articleCommentService.deleteArticleComment(commentId);
-
+    public String deleteArticleComment(
+            @PathVariable Long commentId,
+            @AuthenticationPrincipal BoardPrincipal boardPrincipal,
+            Long articleId
+    ) {
+        articleCommentService.deleteArticleComment(commentId, boardPrincipal.getUsername());
         return "redirect:/articles/" + articleId;
     }
 

--- a/src/main/java/com/fastcampus/mvcboardproject/controller/ArticleController.java
+++ b/src/main/java/com/fastcampus/mvcboardproject/controller/ArticleController.java
@@ -6,6 +6,7 @@ import com.fastcampus.mvcboardproject.dto.UserAccountDto;
 import com.fastcampus.mvcboardproject.dto.request.ArticleRequest;
 import com.fastcampus.mvcboardproject.dto.response.ArticleResponse;
 import com.fastcampus.mvcboardproject.dto.response.ArticleWithCommentsResponse;
+import com.fastcampus.mvcboardproject.dto.security.BoardPrincipal;
 import com.fastcampus.mvcboardproject.service.ArticleService;
 import com.fastcampus.mvcboardproject.service.PaginationService;
 import lombok.RequiredArgsConstructor;
@@ -14,6 +15,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.ModelMap;
 import org.springframework.web.bind.annotation.*;
@@ -93,11 +95,11 @@ public class ArticleController {
     }
 
     @PostMapping ("/form")
-    public String postNewArticle(ArticleRequest articleRequest) {
-        // TODO: 인증 정보를 넣어줘야 한다.
-        articleService.saveArticle(articleRequest.toDto(UserAccountDto.of(
-                "uno", "asdf1234", "uno@mail.com", "Uno", "memo"
-        )));
+    public String postNewArticle(
+            @AuthenticationPrincipal BoardPrincipal boardPrincipal,
+            ArticleRequest articleRequest
+    ) {
+        articleService.saveArticle(articleRequest.toDto(boardPrincipal.toDto()));
 
         return "redirect:/articles";
     }
@@ -114,19 +116,22 @@ public class ArticleController {
 
 
     @PostMapping ("/{articleId}/form")
-    public String updateArticle(@PathVariable Long articleId, ArticleRequest articleRequest) {
-        // TODO: 인증 정보를 넣어줘야 한다.
-        articleService.updateArticle(articleId, articleRequest.toDto(UserAccountDto.of(
-                "uno", "asdf1234", "uno@mail.com", "Uno", "memo"
-        )));
+    public String updateArticle(
+            @PathVariable Long articleId,
+            @AuthenticationPrincipal BoardPrincipal boardPrincipal,
+            ArticleRequest articleRequest
+    ) {
+        articleService.updateArticle(articleId, articleRequest.toDto(boardPrincipal.toDto()));
 
         return "redirect:/articles/" + articleId;
     }
 
     @PostMapping ("/{articleId}/delete")
-    public String deleteArticle(@PathVariable Long articleId) {
-        // TODO: 인증 정보를 넣어줘야 한다.
-        articleService.deleteArticle(articleId);
+    public String deleteArticle(
+            @PathVariable Long articleId,
+            @AuthenticationPrincipal BoardPrincipal boardPrincipal
+    ) {
+        articleService.deleteArticle(articleId, boardPrincipal.getUsername());
 
         return "redirect:/articles";
     }

--- a/src/main/java/com/fastcampus/mvcboardproject/dto/response/ArticleCommentResponse.java
+++ b/src/main/java/com/fastcampus/mvcboardproject/dto/response/ArticleCommentResponse.java
@@ -10,11 +10,12 @@ public record ArticleCommentResponse(
         String content,
         LocalDateTime createdAt,
         String email,
-        String nickname
+        String nickname,
+        String userId
 ) {
 
-    public static ArticleCommentResponse of(Long id, String content, LocalDateTime createdAt, String email, String nickname) {
-        return new ArticleCommentResponse(id, content, createdAt, email, nickname);
+    public static ArticleCommentResponse of(Long id, String content, LocalDateTime createdAt, String email, String nickname, String userId) {
+        return new ArticleCommentResponse(id, content, createdAt, email, nickname, userId);
     }
 
     public static ArticleCommentResponse from(ArticleCommentDto dto) {
@@ -28,7 +29,8 @@ public record ArticleCommentResponse(
                 dto.content(),
                 dto.createdAt(),
                 dto.userAccountDto().email(),
-                nickname
+                nickname,
+                dto.userAccountDto().userId()
         );
     }
 

--- a/src/main/java/com/fastcampus/mvcboardproject/dto/response/ArticleWithCommentsResponse.java
+++ b/src/main/java/com/fastcampus/mvcboardproject/dto/response/ArticleWithCommentsResponse.java
@@ -16,11 +16,12 @@ public record ArticleWithCommentsResponse(
         LocalDateTime createdAt,
         String email,
         String nickname,
+        String userId,
         Set<ArticleCommentResponse> articleCommentsResponse
 ) {
 
-    public static ArticleWithCommentsResponse of(Long id, String title, String content, String hashtag, LocalDateTime createdAt, String email, String nickname, Set<ArticleCommentResponse> articleCommentResponses) {
-        return new ArticleWithCommentsResponse(id, title, content, hashtag, createdAt, email, nickname, articleCommentResponses);
+    public static ArticleWithCommentsResponse of(Long id, String title, String content, String hashtag, LocalDateTime createdAt, String email, String nickname, String userId, Set<ArticleCommentResponse> articleCommentResponses) {
+        return new ArticleWithCommentsResponse(id, title, content, hashtag, createdAt, email, nickname, userId, articleCommentResponses);
     }
 
     public static ArticleWithCommentsResponse from(ArticleWithCommentsDto dto) {
@@ -37,6 +38,7 @@ public record ArticleWithCommentsResponse(
                 dto.createdAt(),
                 dto.userAccountDto().email(),
                 nickname,
+                dto.userAccountDto().userId(),
                 dto.articleCommentDtos().stream()
                         .map(ArticleCommentResponse::from)
                         .collect(Collectors.toCollection(LinkedHashSet::new))

--- a/src/main/java/com/fastcampus/mvcboardproject/repository/ArticleCommentRepository.java
+++ b/src/main/java/com/fastcampus/mvcboardproject/repository/ArticleCommentRepository.java
@@ -20,6 +20,8 @@ public interface ArticleCommentRepository extends
 
     List<ArticleComment> findByArticle_Id(Long articleId);
 
+    void deleteByIdAndUserAccount_UserId(Long articleId, String userid);
+
     @Override
     default void customize(QuerydslBindings bindings, QArticleComment root) {
         bindings.excludeUnlistedProperties(true);

--- a/src/main/java/com/fastcampus/mvcboardproject/repository/ArticleRepository.java
+++ b/src/main/java/com/fastcampus/mvcboardproject/repository/ArticleRepository.java
@@ -26,6 +26,8 @@ public interface ArticleRepository extends
     Page<Article> findByUserAccount_NicknameContaining(String nickname, Pageable pageable);
     Page<Article> findByHashtag(String hashtag, Pageable pageable);  // 해시태그는 일종의 카테고리이기 때문에 정확하게 일치해야 함
 
+    void deleteArticle(Long articleId, String userid);
+
     @Override
     default void customize(QuerydslBindings bindings, QArticle root) {
         bindings.excludeUnlistedProperties(true);

--- a/src/main/java/com/fastcampus/mvcboardproject/repository/ArticleRepository.java
+++ b/src/main/java/com/fastcampus/mvcboardproject/repository/ArticleRepository.java
@@ -26,7 +26,7 @@ public interface ArticleRepository extends
     Page<Article> findByUserAccount_NicknameContaining(String nickname, Pageable pageable);
     Page<Article> findByHashtag(String hashtag, Pageable pageable);  // 해시태그는 일종의 카테고리이기 때문에 정확하게 일치해야 함
 
-    void deleteArticle(Long articleId, String userid);
+    void deleteByIdAndUserAccount_UserId(Long articleId, String userid);
 
     @Override
     default void customize(QuerydslBindings bindings, QArticle root) {

--- a/src/main/java/com/fastcampus/mvcboardproject/service/ArticleCommentService.java
+++ b/src/main/java/com/fastcampus/mvcboardproject/service/ArticleCommentService.java
@@ -55,10 +55,10 @@ public class ArticleCommentService {
         }
     }
 
-    public void deleteArticleComment(Long articleCommentId) {
+    public void deleteArticleComment(long articleCommentId, String userId) {
         // 1. 댓글 정보 가져오기 -> 없으면 경고   2.댓글 없애기
         try{
-            articleCommentRepository.deleteById(articleCommentId);
+            articleCommentRepository.deleteByIdAndUserAccount_UserId(articleCommentId, userId);
         }catch (EntityNotFoundException e){
             log.warn("존재하지 않는 댓글입니다. 댓글 번호: {}", articleCommentId);
         }

--- a/src/main/java/com/fastcampus/mvcboardproject/service/ArticleService.java
+++ b/src/main/java/com/fastcampus/mvcboardproject/service/ArticleService.java
@@ -79,17 +79,21 @@ public class ArticleService {
     public void updateArticle(Long articleId, ArticleDto dto) {
         try {
             Article article = articleRepository.getReferenceById(articleId);
-            if (dto.title() != null) { article.setTitle(dto.title()); } // not null필드에 대한 방어로직
-            if (dto.content() != null) { article.setContent(dto.content()); }
-            article.setHashtag(dto.hashtag());
+            UserAccount userAccount = userAccountRepository.getReferenceById(dto.userAccountDto().userId());
+
+            if (article.getUserAccount().equals(userAccount)) {
+                if (dto.title() != null) { article.setTitle(dto.title()); }   //null 방어로직
+                if (dto.content() != null) { article.setContent(dto.content()); }
+                article.setHashtag(dto.hashtag());
+            }
         } catch (EntityNotFoundException e) {
-            log.warn("게시글 업데이트 실패. 게시글을 찾을 수 없습니다 - dto: {}", dto);
+            log.warn("게시글 업데이트 실패. 게시글을 수정하는데 필요한 정보를 찾을 수 없습니다 - {}", e.getLocalizedMessage());
         }
     }
 
-    public void deleteArticle(long articleId) {
+    public void deleteArticle(long articleId, String userId) {
         try{
-            articleRepository.deleteById(articleId);
+            articleRepository.deleteArticle(articleId, userId);
         }catch (EntityNotFoundException e){
         }
     }

--- a/src/main/java/com/fastcampus/mvcboardproject/service/ArticleService.java
+++ b/src/main/java/com/fastcampus/mvcboardproject/service/ArticleService.java
@@ -79,7 +79,7 @@ public class ArticleService {
     public void updateArticle(Long articleId, ArticleDto dto) {
         try {
             Article article = articleRepository.getReferenceById(articleId);
-            UserAccount userAccount = userAccountRepository.getReferenceById(dto.userAccountDto().userId());
+            UserAccount userAccount = userAccountRepository.getReferenceById(dto.userAccountDto().userId());   //articleRequest.toDto(boardPrincipal.toDto()
 
             if (article.getUserAccount().equals(userAccount)) {
                 if (dto.title() != null) { article.setTitle(dto.title()); }   //null 방어로직
@@ -93,7 +93,7 @@ public class ArticleService {
 
     public void deleteArticle(long articleId, String userId) {
         try{
-            articleRepository.deleteArticle(articleId, userId);
+            articleRepository.deleteByIdAndUserAccount_UserId(articleId, userId);
         }catch (EntityNotFoundException e){
         }
     }

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,10 +1,10 @@
 -- 테스트 계정
 -- TODO: 테스트용이지만 비밀번호가 노출된 데이터 세팅. 개선하는 것이 좋을 지 고민해 보자.
 insert into user_account (user_id, user_password, nickname, email, memo, created_at, created_by, modified_at, modified_by) values
-('uno', 'asdf1234', 'Uno', 'uno@mail.com', 'I am Uno.', now(), 'uno', now(), 'uno')
+('uno', '{noop}asdf1234', 'Uno', 'uno@mail.com', 'I am Uno.', now(), 'uno', now(), 'uno')
 ;
 insert into user_account (user_id, user_password, nickname, email, memo, created_at, created_by, modified_at, modified_by) values
-('uno2', 'asdf1234', 'Uno2', 'uno2@mail.com', 'I am Uno2.', now(), 'uno2', now(), 'uno2')
+('uno2', '{noop}asdf1234', 'Uno2', 'uno2@mail.com', 'I am Uno2.', now(), 'uno2', now(), 'uno2')
 ;
 
 -- 123 게시글

--- a/src/main/resources/templates/articles/detail.html
+++ b/src/main/resources/templates/articles/detail.html
@@ -74,20 +74,25 @@
                     Lorem ipsum dolor sit amet
                   </p>
                 </div>
-                <div class="col-2 mb-3">
+                <div class="col-2 mb-3 align-self-center">
                   <button type="submit" class="btn btn-outline-danger" id="delete-comment-button">삭제</button>
                 </div>
               </div>
             </form>
           </li>
           <li>
-            <div>
-              <strong>Uno</strong>
-              <small><time>2022-01-01</time></small>
-              <p>
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit.<br>
-                Lorem ipsum dolor sit amet
-              </p>
+            <div class="row">
+              <div class="col-md-10 col-lg-9">
+                <strong>Uno2</strong>
+                <small><time>2022-01-01</time></small>
+                <p>
+                  Lorem ipsum dolor sit amet, consectetur adipiscing elit.<br>
+                  Lorem ipsum dolor sit amet
+                </p>
+              </div>
+              <div class="col-2 mb-3">
+                <button type="submit" class="btn btn-outline-danger" hidden>삭제</button>
+              </div>
             </div>
           </li>
         </ul>

--- a/src/main/resources/templates/articles/detail.th.xml
+++ b/src/main/resources/templates/articles/detail.th.xml
@@ -11,7 +11,7 @@
     <attr sel="#hashtag" th:text="*{hashtag}" />
     <attr sel="#article-content/pre" th:text="*{content}" />
 
-    <attr sel="#article-buttons">
+    <attr sel="#article-buttons" th:if="${#authorization.expression('isAuthenticated()')} and *{userId} == ${#authentication.name}">
       <attr sel="#delete-article-form" th:action="'/articles/' + *{id} + '/delete'" th:method="post">
         <attr sel="#update-article" th:href="'/articles/' + *{id} + '/form'" />
       </attr>
@@ -28,6 +28,7 @@
           <attr sel="div/strong" th:text="${articleComment.nickname}" />
           <attr sel="div/small/time" th:datetime="${articleComment.createdAt}" th:text="${#temporals.format(articleComment.createdAt, 'yyyy-MM-dd HH:mm:ss')}" />
           <attr sel="div/p" th:text="${articleComment.content}" />
+          <attr sel="button" th:if="${#authorization.expression('isAuthenticated()')} and ${articleComment.userId} == ${#authentication.name}" />
         </attr>
       </attr>
     </attr>

--- a/src/main/resources/templates/articles/index.th.xml
+++ b/src/main/resources/templates/articles/index.th.xml
@@ -53,7 +53,7 @@
       </attr>
     </attr>
 
-    <attr sel="#write-article" th:href="@{/articles/form}" />
+    <attr sel="#write-article" sec:authorize="isAuthenticated()" th:href="@{/articles/form}" />
 
     <attr sel="#pagination">
       <attr sel="li[0]/a"

--- a/src/main/resources/templates/header.html
+++ b/src/main/resources/templates/header.html
@@ -9,13 +9,14 @@
     <div class="container">
       <div class="d-flex flex-wrap align-items-center justify-content-center justify-content-lg-start">
         <ul class="nav col-12 col-lg-auto me-lg-auto mb-2 justify-content-center mb-md-0">
-          <li><a href="/" class="nav-link px-2 text-secondary">Home</a></li>
-          <li><a href="/articles/search-hashtag" class="nav-link px-2 text-secondary">Hashtag</a></li>
+          <li><a id="home" href="#" class="nav-link px-2 text-secondary">Home</a></li>
+          <li><a id="hashtag" href="#" class="nav-link px-2 text-secondary">Hashtags</a></li>
         </ul>
 
         <div class="text-end">
-          <button type="button" class="btn btn-outline-light me-2">Login</button>
-          <button type="button" class="btn btn-warning">Sign-up</button>
+          <span id="username" class="text-white me-2">username</span>
+          <a role="button" id="login" href="/login" class="btn btn-outline-light me-2">Login</a>
+          <a role="button" id="logout" class="btn btn-outline-light me-2">Logout</a>
         </div>
       </div>
     </div>

--- a/src/main/resources/templates/header.th.xml
+++ b/src/main/resources/templates/header.th.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<thlogic>
+  <attr sel="#home" th:href="@{/}" />
+  <attr sel="#hashtag" th:href="@{/articles/search-hashtag}" />
+  <attr sel="#username" sec:authorize="isAuthenticated()" sec:authentication="name" />
+  <attr sel="#login" sec:authorize="!isAuthenticated()" th:href="@{/login}" />
+  <attr sel="#logout" sec:authorize="isAuthenticated()" th:href="@{/logout}" />
+</thlogic>

--- a/src/test/java/com/fastcampus/mvcboardproject/controller/ArticleCommentControllerTest.java
+++ b/src/test/java/com/fastcampus/mvcboardproject/controller/ArticleCommentControllerTest.java
@@ -1,6 +1,7 @@
 package com.fastcampus.mvcboardproject.controller;
 
 import com.fastcampus.mvcboardproject.config.SecurityConfig;
+import com.fastcampus.mvcboardproject.config.TestSecurityConfig;
 import com.fastcampus.mvcboardproject.dto.ArticleCommentDto;
 import com.fastcampus.mvcboardproject.dto.request.ArticleCommentRequest;
 import com.fastcampus.mvcboardproject.service.ArticleCommentService;
@@ -12,6 +13,8 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.TestExecutionEvent;
+import org.springframework.security.test.context.support.WithUserDetails;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.Map;
@@ -25,7 +28,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
 
 @DisplayName("View 컨트롤러 - 댓글")
-@Import({SecurityConfig.class, FormDataEncoder.class})
+@Import({TestSecurityConfig.class, FormDataEncoder.class})
 @WebMvcTest(ArticleCommentController.class)
 class ArticleCommentControllerTest {
 
@@ -44,7 +47,7 @@ class ArticleCommentControllerTest {
         this.formDataEncoder = formDataEncoder;
     }
 
-
+    @WithUserDetails(value = "unoTest", setupBefore = TestExecutionEvent.TEST_EXECUTION)
     @DisplayName("[view][POST] 댓글 등록 - 정상 호출")
     @Test
     void givenArticleCommentInfo_whenRequesting_thenSavesNewArticleComment() throws Exception {
@@ -66,13 +69,16 @@ class ArticleCommentControllerTest {
         then(articleCommentService).should().saveArticleComment(any(ArticleCommentDto.class));
     }
 
+    @WithUserDetails(value = "unoTest", setupBefore = TestExecutionEvent.TEST_EXECUTION)
     @DisplayName("[view][GET] 댓글 삭제 - 정상 호출")
     @Test
     void givenArticleCommentIdToDelete_whenRequesting_thenDeletesArticleComment() throws Exception {
         // Given
         long articleId = 1L;
         long articleCommentId = 1L;
-        willDoNothing().given(articleCommentService).deleteArticleComment(articleCommentId);
+        String userId = "unoTest";
+
+        willDoNothing().given(articleCommentService).deleteArticleComment(articleCommentId, userId);
 
         // When & Then
         mvc.perform(
@@ -84,6 +90,6 @@ class ArticleCommentControllerTest {
                 .andExpect(status().is3xxRedirection())
                 .andExpect(view().name("redirect:/articles/" + articleId))
                 .andExpect(redirectedUrl("/articles/" + articleId));
-        then(articleCommentService).should().deleteArticleComment(articleCommentId);
+        then(articleCommentService).should().deleteArticleComment(articleCommentId, userId);
     }
 }

--- a/src/test/java/com/fastcampus/mvcboardproject/controller/AuthControllerTest.java
+++ b/src/test/java/com/fastcampus/mvcboardproject/controller/AuthControllerTest.java
@@ -1,6 +1,7 @@
 package com.fastcampus.mvcboardproject.controller;
 
 import com.fastcampus.mvcboardproject.config.SecurityConfig;
+import com.fastcampus.mvcboardproject.config.TestSecurityConfig;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -8,13 +9,14 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @DisplayName("View 컨트롤러 - 인증")
-@Import(SecurityConfig.class)
+@Import(TestSecurityConfig.class)
 @WebMvcTest(MainController.class)
 public class AuthControllerTest {
 
@@ -25,7 +27,7 @@ public class AuthControllerTest {
     }
 
 
-    @DisplayName("[view][GET] 로그인 페이지 - 정상 호출")
+    @DisplayName("spring security 라이브러리로 추가된 login 페이지 출력 테스트")
     @Test
     public void givenNothing_whenTryingToLogIn_thenReturnsLogInView() throws Exception {
         // Given

--- a/src/test/java/com/fastcampus/mvcboardproject/controller/MainControllerTest.java
+++ b/src/test/java/com/fastcampus/mvcboardproject/controller/MainControllerTest.java
@@ -1,6 +1,7 @@
 package com.fastcampus.mvcboardproject.controller;
 
 import com.fastcampus.mvcboardproject.config.SecurityConfig;
+import com.fastcampus.mvcboardproject.config.TestSecurityConfig;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -11,7 +12,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-@Import(SecurityConfig.class)      //
+@Import(TestSecurityConfig.class)      //
 @WebMvcTest(MainController.class)  // 테스트 대상을 작성하여 빈 스캐닝 최소화
 class MainControllerTest {
 

--- a/src/test/java/com/fastcampus/mvcboardproject/service/ArticleCommentServiceTest.java
+++ b/src/test/java/com/fastcampus/mvcboardproject/service/ArticleCommentServiceTest.java
@@ -126,16 +126,17 @@ class ArticleCommentServiceTest {
 
     @Test
     @DisplayName("[댓글 삭제] 댓글 ID를 입력하면, 댓글을 삭제한다.")
-    void givenArticleCommentId_whenDeleteArticleComment_thenDeleteArticleComment() {
+    void givenArticleCommentId_whenDeletingArticleComment_thenDeletesArticleComment() {
         // Given
         Long articleCommentId = 1L;
-        willDoNothing().given(articleCommentRepository).deleteById(articleCommentId);
+        String userId = "uno";
+        willDoNothing().given(articleCommentRepository).deleteByIdAndUserAccount_UserId(articleCommentId, userId);
 
         // When
-        sut.deleteArticleComment(articleCommentId);
+        sut.deleteArticleComment(articleCommentId, userId);
 
         // Then
-        then(articleCommentRepository).should().deleteById(articleCommentId);
+        then(articleCommentRepository).should().deleteByIdAndUserAccount_UserId(articleCommentId, userId);
     }
 
     private ArticleCommentDto createArticleCommentDto(String content) {

--- a/src/test/java/com/fastcampus/mvcboardproject/service/ArticleServiceTest.java
+++ b/src/test/java/com/fastcampus/mvcboardproject/service/ArticleServiceTest.java
@@ -251,13 +251,13 @@ class ArticleServiceTest {
         // Given
         Long articleId = 1L;
         String userId = "uno";
-        willDoNothing().given(articleRepository).deleteArticle(articleId, userId);
+        willDoNothing().given(articleRepository).deleteByIdAndUserAccount_UserId(articleId, userId);
 
         // When
         sut.deleteArticle(1L, userId);
 
         // Then
-        then(articleRepository).should().deleteArticle(articleId, userId);
+        then(articleRepository).should().deleteByIdAndUserAccount_UserId(articleId, userId);
     }
 
     // --------  테스트에서 사용되는 가짜(Article) 객체를 생성하는 유틸리티 메서드 -------

--- a/src/test/java/com/fastcampus/mvcboardproject/service/ArticleServiceTest.java
+++ b/src/test/java/com/fastcampus/mvcboardproject/service/ArticleServiceTest.java
@@ -17,6 +17,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDateTime;
@@ -216,6 +217,7 @@ class ArticleServiceTest {
         // dto = ArticleDto.of(1L, createUserAccountDto(), title, content, hashtag, LocalDateTime.now(), "Uno", LocalDateTime.now(), "Uno")
 
         given(articleRepository.getReferenceById(dto.id())).willReturn(article);
+        given(userAccountRepository.getReferenceById(dto.userAccountDto().userId())).willReturn(dto.userAccountDto().toEntity());
 
         // When
         sut.updateArticle(dto.id(), dto);
@@ -226,6 +228,7 @@ class ArticleServiceTest {
                 .hasFieldOrPropertyWithValue("content", dto.content())
                 .hasFieldOrPropertyWithValue("hashtag", dto.hashtag());
         then(articleRepository).should().getReferenceById(dto.id());
+        then(userAccountRepository).should().getReferenceById(dto.userAccountDto().userId());
     }
 
     @DisplayName("[없는 게시글 수정] 없는 게시글의 수정 정보를 입력하면, 경고 로그를 찍고 아무 것도 하지 않는다.")
@@ -247,13 +250,14 @@ class ArticleServiceTest {
     void givenArticleId_whenDeletingArticle_thenDeletesArticle() {
         // Given
         Long articleId = 1L;
-        willDoNothing().given(articleRepository).deleteById(articleId);
+        String userId = "uno";
+        willDoNothing().given(articleRepository).deleteArticle(articleId, userId);
 
         // When
-        sut.deleteArticle(1L);
+        sut.deleteArticle(1L, userId);
 
         // Then
-        then(articleRepository).should().deleteById(articleId);
+        then(articleRepository).should().deleteArticle(articleId, userId);
     }
 
     // --------  테스트에서 사용되는 가짜(Article) 객체를 생성하는 유틸리티 메서드 -------


### PR DESCRIPTION
- Controller 테스트에 테스트용 security config를 적용하고, 
- @WithMockUser나 @WithUserDetails를 이용하여 인증된 요청임을 명시하였다. 
- Controller에서 사용자의 principal정보를 받아 DTO로 변환하여 UserAccount정보를 얻고,
- 이를 이용해 게시글 또는 댓글 작성자와 일치하는지 확인하는 로직을 추가했다. (Post, 생성, 수정, 삭제)

- 그 외, TestSecurityConfig를 적용하지 않은 다른 테스트에도 Import를 해주고,
- 타임리프 문법을 이용해 View에 나오는 로그인, 로그아웃, 수정, 삭제 노출 여부를 인증에 따라 결정할 수 있게 적용했다.
- PassWordEncoder인식할 수 있게 SQL 데이터 변경하고,
- 타임리프에서 게시글, 댓글을 받을 때, 수정삭제에 대한 노출을 사용자 확인을 통해 결정해야 하므로 Response Dto에 userId를 추가했다.