### PR TITLE
#59 - 엔티티 equals(), hashcode() 비교 로직에 getter 적용 및 Auth컨트롤러 테스트 수정

### DIFF
--- a/src/main/java/com/fastcampus/mvcboardproject/domain/Article.java
+++ b/src/main/java/com/fastcampus/mvcboardproject/domain/Article.java
@@ -67,11 +67,11 @@ public class Article extends AuditingFields  {
         if (!(o instanceof Article article)) return false;
         // id가 null이 아니고(아이디가 부여되지않음), PK인 id가 동일하다면, 같음.
         // (영속화하지 않았을 경우, 동등성 검사에서 탈락)
-        return id != null && id.equals(article.id);
+        return this.getId() != null && this.getId().equals(article.id);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id);
+        return Objects.hash(this.getId());
     }
 }

--- a/src/main/java/com/fastcampus/mvcboardproject/domain/ArticleComment.java
+++ b/src/main/java/com/fastcampus/mvcboardproject/domain/ArticleComment.java
@@ -50,12 +50,12 @@ public class ArticleComment extends AuditingFields {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof ArticleComment that)) return false;
-        return id != null && id.equals(that.id);
+        return this.getId() != null && this.getId().equals(that.id);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id);
+        return Objects.hash(this.getId());
     }
 
 }

--- a/src/main/java/com/fastcampus/mvcboardproject/domain/UserAccount.java
+++ b/src/main/java/com/fastcampus/mvcboardproject/domain/UserAccount.java
@@ -49,11 +49,11 @@ public class UserAccount extends AuditingFields {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof UserAccount userAccount)) return false;
-        return userId != null && userId.equals(userAccount.userId);
+        return this.getUserId() != null && this.getUserId().equals(userAccount.userId);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(userId);
+        return Objects.hash(this.getUserId());
     }
 }

--- a/src/test/java/com/fastcampus/mvcboardproject/controller/AuthControllerTest.java
+++ b/src/test/java/com/fastcampus/mvcboardproject/controller/AuthControllerTest.java
@@ -1,6 +1,8 @@
 package com.fastcampus.mvcboardproject.controller;
 
 import com.fastcampus.mvcboardproject.config.TestSecurityConfig;
+import com.fastcampus.mvcboardproject.service.ArticleService;
+import com.fastcampus.mvcboardproject.service.PaginationService;
 import com.fastcampus.mvcboardproject.service.UserAccountService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -10,35 +12,32 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
-
+import static org.mockito.BDDMockito.then;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @DisplayName("View 컨트롤러 - 인증")
 @Import(TestSecurityConfig.class)
 @WebMvcTest(MainController.class)
-public class AuthControllerTest {
+class AuthControllerTest {
 
     private final MockMvc mvc;
-
-    @MockBean
-    private UserAccountService userAccountService;
-
-    public AuthControllerTest(@Autowired MockMvc mvc) {
+    @MockBean private ArticleService articleService;
+    @MockBean private UserAccountService userAccountService;
+    @MockBean private PaginationService paginationService;
+    AuthControllerTest(@Autowired MockMvc mvc) {
         this.mvc = mvc;
     }
-
-
-    @DisplayName("spring security 라이브러리로 추가된 login 페이지 출력 테스트")
+    @DisplayName("[view][GET] 로그인 페이지 - 정상 호출")
     @Test
     void givenNothing_whenTryingToLogIn_thenReturnsLogInView() throws Exception {
         // Given
-
         // When & Then
         mvc.perform(get("/login"))
                 .andExpect(status().isOk())
-                .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
-                .andExpect(view().name("login"));
+                .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML));
+        then(articleService).shouldHaveNoInteractions();
+        then(paginationService).shouldHaveNoInteractions();
     }
-
 }


### PR DESCRIPTION
- 여기서 필드에 직접 접근하면, 하이버네이트가 지연 로딩하려고 만든 프록시 객체를 다룰 때 필드 값이 `null`일 수 있음
- 그러면 제대로 비교 로직을 수행할 수 없기 떄문에 getter를 이용함. 이것으로 프록시 객체를 타더라도 제대로 값을 읽어올 수 있음.
- 페이지네이션과 게시글을 가지고 오는 서비스 로직에 대한 검사를 추가하였고, 강의와 다르게 Main컨트롤러에 login에 대한 매칭을 정의했기 때문에, 이에 맞게 변경하였음.

This closed #59 