### PR TITLE
[고도화] 해시태그 검색 기능 고도화

### DIFF
--- a/src/main/java/com/fastcampus/mvcboardproject/controller/ArticleController.java
+++ b/src/main/java/com/fastcampus/mvcboardproject/controller/ArticleController.java
@@ -53,6 +53,7 @@ public class ArticleController {
         map.addAttribute("articles", articles);
         map.addAttribute("paginationBarNumbers", barNumbers);
         map.addAttribute("searchTypes", SearchType.values());
+        map.addAttribute("searchTypeHashtag", SearchType.HASHTAG);
 
         return "articles/index"; // "articles/index"를 반환(컨트롤러가 렌더링할 뷰의 이름)
     }
@@ -64,6 +65,7 @@ public class ArticleController {
         map.addAttribute("article", article);
         map.addAttribute("articleComments", article.articleCommentsResponse());
         map.addAttribute("totalCount", articleService.getArticleCount());
+        map.addAttribute("searchTypeHashtag", SearchType.HASHTAG);
 
         return "articles/detail";
     }

--- a/src/main/java/com/fastcampus/mvcboardproject/service/HashtagService.java
+++ b/src/main/java/com/fastcampus/mvcboardproject/service/HashtagService.java
@@ -1,19 +1,59 @@
 package com.fastcampus.mvcboardproject.service;
 
 import com.fastcampus.mvcboardproject.domain.Hashtag;
+import com.fastcampus.mvcboardproject.repository.HashtagRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import java.util.Set;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.util.HashSet;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Transactional
+@RequiredArgsConstructor
 @Service
 public class HashtagService {
+
+    private final HashtagRepository hashtagRepository;
+
+    @Transactional(readOnly = true)
+    public Set<Hashtag> findHashtagsByNames(Set<String> hashtagNames) {
+        // 해시태그 이름을 가진 해시태그들을 가져오고, 중복 없는 Set으로 변환
+        return new HashSet<>(hashtagRepository.findByHashtagNameIn(hashtagNames));
+    }
+
     public Set<String> parseHashtagNames(String content) {
-        return null;
+        /*
+        content 내에서 해시태그를 파싱하여 해시태그 이름들을 가져온다.
+        content가 없으면 파싱할 필요가 없어, set은 비어있고,
+        파싱을 위한 패턴은 #으로 시작하고, 알파벳, 숫자, 한글, _이 오는 문자열을 가져온다.
+        매칭된 문자열은 #을 빼고 Set에 추가하고, 최종 결과를 불변 객체로 만든다.
+        */
+        if (content == null) {
+            return Set.of();
+        }
+
+        Pattern pattern = Pattern.compile("#[\\w가-힣]+");
+        Matcher matcher = pattern.matcher(content.strip());
+        Set<String> result = new HashSet<>();
+
+        while (matcher.find()) {
+            result.add(matcher.group().replace("#", ""));
+        }
+
+        return Set.copyOf(result);
     }
 
-    public Set<Hashtag> findHashtagsByNames(Set<String> expectedHashtagNames) {
-        return null;
-    }
-
-    public void deleteHashtagWithoutArticles(Object any) {
+    public void deleteHashtagWithoutArticles(Long hashtagId) {
+        /*
+        해시태그 아이디를 가지고 조회하였을 때, 게시글 목록이 있으면 삭제하지 않고,
+        게시글 목록이 비어있으면 삭제한다.
+         */
+        Hashtag hashtag = hashtagRepository.getReferenceById(hashtagId);
+        if (hashtag.getArticles().isEmpty()) {
+            hashtagRepository.delete(hashtag);
+        }
     }
 }

--- a/src/main/resources/templates/articles/detail.html
+++ b/src/main/resources/templates/articles/detail.html
@@ -29,7 +29,7 @@
           <p><span id="nickname">Uno</span></p>
           <p><a id="email" href="mailto:djkehh@gmail.com">uno@mail.com</a></p>
           <p><time id="created-at" datetime="2022-01-01T00:00:00">2022-01-01</time></p>
-          <p><span id="hashtag">#java</span></p>
+          <p><span id="hashtag" class="badge text-bg-secondary mx-1"><a class="text-reset">#java</a></span></p>
         </aside>
       </section>
 

--- a/src/main/resources/templates/articles/detail.th.xml
+++ b/src/main/resources/templates/articles/detail.th.xml
@@ -8,7 +8,13 @@
     <attr sel="#nickname" th:text="*{nickname}" />
     <attr sel="#email" th:text="*{email}" />
     <attr sel="#created-at" th:datetime="*{createdAt}" th:text="*{#temporals.format(createdAt, 'yyyy-MM-dd HH:mm:ss')}" />
-    <attr sel="#hashtag" th:text="*{hashtag}" />
+    <attr sel="#hashtag" th:each="hashtag : ${article.hashtags}">
+      <attr sel="a"
+            th:text="'#' + ${hashtag}"
+            th:href="@{/articles(searchType=${searchTypeHashtag},searchValue=${hashtag})}"
+      />
+    </attr>
+
     <attr sel="#article-content/pre" th:text="*{content}" />
 
     <attr sel="#article-buttons" th:if="${#authorization.expression('isAuthenticated()')} and *{userId} == ${#authentication.name}">

--- a/src/main/resources/templates/articles/form.html
+++ b/src/main/resources/templates/articles/form.html
@@ -35,12 +35,6 @@
           <textarea class="form-control" id="content" name="content" rows="5" required></textarea>
         </div>
       </div>
-      <div class="row mb-4 justify-content-md-center">
-        <label for="hashtag" class="col-sm-2 col-lg-1 col-form-label text-sm-end">해시태그</label>
-        <div class="col-sm-8 col-lg-9">
-          <input type="text" class="form-control" id="hashtag" name="hashtag">
-        </div>
-      </div>
       <div class="row mb-5 justify-content-md-center">
         <div class="col-sm-10 d-grid gap-2 d-sm-flex justify-content-sm-end">
           <button type="submit" class="btn btn-primary" id="submit-button">저장</button>

--- a/src/main/resources/templates/articles/form.th.xml
+++ b/src/main/resources/templates/articles/form.th.xml
@@ -8,7 +8,6 @@
   <attr sel="#article-form" th:action="${formStatus?.update} ? '/articles/' + ${article.id} + '/form' : '/articles/form'" th:method="post">
     <attr sel="#title" th:value="${article?.title} ?: _" />
     <attr sel="#content" th:text="${article?.content} ?: _" />
-    <attr sel="#hashtag" th:value="${article?.hashtag} ?: _" />
     <attr sel="#submit-button" th:text="${formStatus?.description} ?: _" />
     <attr sel="#cancel-button" th:onclick="'history.back()'" />
   </attr>

--- a/src/main/resources/templates/articles/index.html
+++ b/src/main/resources/templates/articles/index.html
@@ -70,7 +70,7 @@
         <tbody>
         <tr>
           <td class="title"><a>첫글</a></td>
-          <td class="hashtag">#java</td>
+          <td class="hashtag"><span class="badge text-bg-secondary mx-1"><a class="text-reset">#java</a></span></td>
           <td class="user-id">Uno</td>
           <td class="created-at"><time>2022-01-01</time></td>
         </tr>

--- a/src/main/resources/templates/articles/index.th.xml
+++ b/src/main/resources/templates/articles/index.th.xml
@@ -25,7 +25,7 @@
         )}"/>
         <attr sel="th.hashtag/a" th:text="'해시태그'" th:href="@{/articles(
             page=${articles.number},
-            sort='hashtag' + (*{sort.getOrderFor('hashtag')} != null ? (*{sort.getOrderFor('hashtag').direction.name} != 'DESC' ? ',desc' : '') : ''),
+            sort='hashtags' + (*{sort.getOrderFor('hashtags')} != null ? (*{sort.getOrderFor('hashtags').direction.name} != 'DESC' ? ',desc' : '') : ''),
             searchType=${param.searchType},
             searchValue=${param.searchValue}
         )}"/>
@@ -46,7 +46,12 @@
       <attr sel="tbody" th:remove="all-but-first">
         <attr sel="tr[0]" th:each="article : ${articles}">
           <attr sel="td.title/a" th:text="${article.title}" th:href="@{'/articles/' + ${article.id}}" />
-          <attr sel="td.hashtag" th:text="${article.hashtag}" />
+          <attr sel="td.hashtag/span" th:each="hashtag : ${article.hashtags}">
+            <attr sel="a"
+                  th:text="'#' + ${hashtag}"
+                  th:href="@{/articles(searchType=${searchTypeHashtag},searchValue=${hashtag})}"
+            />
+          </attr>
           <attr sel="td.user-id" th:text="${article.nickname}" />
           <attr sel="td.created-at/time" th:datetime="${article.createdAt}" th:text="${#temporals.format(article.createdAt, 'yyyy-MM-dd')}" />
         </attr>

--- a/src/test/java/com/fastcampus/mvcboardproject/service/HashtagServiceTest.java
+++ b/src/test/java/com/fastcampus/mvcboardproject/service/HashtagServiceTest.java
@@ -1,0 +1,146 @@
+package com.fastcampus.mvcboardproject.service;
+
+import com.fastcampus.mvcboardproject.domain.Article;
+import com.fastcampus.mvcboardproject.domain.Hashtag;
+import com.fastcampus.mvcboardproject.repository.HashtagRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.*;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+
+@DisplayName("비즈니스 로직 - 해시태그")
+@ExtendWith(MockitoExtension.class)
+class HashtagServiceTest {
+
+    @InjectMocks private HashtagService sut;
+
+    @Mock private HashtagRepository hashtagRepository;
+
+    @DisplayName("본문을 파싱하면, 해시태그 이름들을 중복 없이 반환한다.")
+    @MethodSource
+    @ParameterizedTest(name = "[{index}] \"{0}\" => {1}")
+    void givenContent_whenParsing_thenReturnsUniqueHashtagNames(String input, Set<String> expected) {
+        // Given
+
+        // When
+        Set<String> actual = sut.parseHashtagNames(input);
+
+        // Then
+        assertThat(actual).containsExactlyInAnyOrderElementsOf(expected);
+        then(hashtagRepository).shouldHaveNoInteractions();
+    }
+
+    static Stream<Arguments> givenContent_whenParsing_thenReturnsUniqueHashtagNames() {
+        return Stream.of(
+                arguments(null, Set.of()),
+                arguments("", Set.of()),
+                arguments("   ", Set.of()),
+                arguments("#", Set.of()),
+                arguments("  #", Set.of()),
+                arguments("#   ", Set.of()),
+                arguments("java", Set.of()),
+                arguments("java#", Set.of()),
+                arguments("ja#va", Set.of("va")),
+                arguments("#java", Set.of("java")),
+                arguments("#java_spring", Set.of("java_spring")),
+                arguments("#java-spring", Set.of("java")),
+                arguments("#_java_spring", Set.of("_java_spring")),
+                arguments("#-java-spring", Set.of()),
+                arguments("#_java_spring__", Set.of("_java_spring__")),
+                arguments("#java#spring", Set.of("java", "spring")),
+                arguments("#java #spring", Set.of("java", "spring")),
+                arguments("#java  #spring", Set.of("java", "spring")),
+                arguments("#java   #spring", Set.of("java", "spring")),
+                arguments("#java     #spring", Set.of("java", "spring")),
+                arguments("  #java     #spring ", Set.of("java", "spring")),
+                arguments("   #java     #spring   ", Set.of("java", "spring")),
+                arguments("#java#spring#부트", Set.of("java", "spring", "부트")),
+                arguments("#java #spring#부트", Set.of("java", "spring", "부트")),
+                arguments("#java#spring #부트", Set.of("java", "spring", "부트")),
+                arguments("#java,#spring,#부트", Set.of("java", "spring", "부트")),
+                arguments("#java.#spring;#부트", Set.of("java", "spring", "부트")),
+                arguments("#java|#spring:#부트", Set.of("java", "spring", "부트")),
+                arguments("#java #spring  #부트", Set.of("java", "spring", "부트")),
+                arguments("   #java,? #spring  ...  #부트 ", Set.of("java", "spring", "부트")),
+                arguments("#java#java#spring#부트", Set.of("java", "spring", "부트")),
+                arguments("#java#java#java#spring#부트", Set.of("java", "spring", "부트")),
+                arguments("#java#spring#java#부트#java", Set.of("java", "spring", "부트")),
+                arguments("#java#스프링 아주 긴 글~~~~~~~~~~~~~~~~~~~~~", Set.of("java", "스프링")),
+                arguments("아주 긴 글~~~~~~~~~~~~~~~~~~~~~#java#스프링", Set.of("java", "스프링")),
+                arguments("아주 긴 글~~~~~~#java#스프링~~~~~~~~~~~~~~~", Set.of("java", "스프링")),
+                arguments("아주 긴 글~~~~~~#java~~~~~~~#스프링~~~~~~~~", Set.of("java", "스프링"))
+        );
+    }
+
+    @DisplayName("해시태그 이름들을 입력하면, 저장된 해시태그 중 이름에 매칭하는 것들을 중복 없이 반환한다.")
+    @Test
+    void givenHashtagNames_whenFindingHashtags_thenReturnsHashtagSet() {
+        // Given
+        Set<String> hashtagNames = Set.of("java", "spring", "boots");
+        given(hashtagRepository.findByHashtagNameIn(hashtagNames)).willReturn(List.of(
+                Hashtag.of("java"),
+                Hashtag.of("spring")
+        ));
+
+        // When
+        Set<Hashtag> hashtags = sut.findHashtagsByNames(hashtagNames);
+
+        // Then
+        assertThat(hashtags).hasSize(2);
+        then(hashtagRepository).should().findByHashtagNameIn(hashtagNames);
+    }
+
+    @Test
+    @DisplayName("게시글이 남아있는 경우, 해시태그를 삭제하지 않는다.")
+    void givenHashtagId_whenHavingArticles_thenDeletesHashtag() {
+        // Given
+        Long hashtagId = 1L;
+        Hashtag hashtag = mock(Hashtag.class);                                      // Hashtag 모의 객체 생성
+        Set<Article> articles = new LinkedHashSet<>();
+        articles.add(mock(Article.class));                                          // 비어 있지 않은 Set<Article>
+
+        given(hashtagRepository.getReferenceById(hashtagId)).willReturn(hashtag);
+        given(hashtag.getArticles()).willReturn(articles);                          // 비어 있지 않은 Set 반환 설정
+
+        // When
+        sut.deleteHashtagWithoutArticles(hashtagId);
+
+        // Then
+        assertThat(articles).hasSize(1);
+        then(hashtagRepository).should(never()).delete(hashtag);
+    }
+
+    @Test
+    @DisplayName("게시글이 남아있지 않은 경우, 해시태그를 삭제한다.")
+    void givenHashtagId_whenNotHavingArticles_thenDeletesHashtag() {
+        // Given
+        Long hashtagId = 1L;
+        Hashtag hashtag = mock(Hashtag.class);
+        Set<Article> articles = new LinkedHashSet<>();                              // 비어있는 Set<Article>
+
+        given(hashtagRepository.getReferenceById(hashtagId)).willReturn(hashtag);
+        given(hashtag.getArticles()).willReturn(articles);                          // 비어 있지 Set 반환 설정
+
+        // When
+        sut.deleteHashtagWithoutArticles(hashtagId);
+
+        // Then
+        assertThat(articles).hasSize(0);
+        then(hashtagRepository).should().delete(hashtag);
+    }
+}


### PR DESCRIPTION
해시태그 기능을 고도화 했다.
기존에 1개만 등록 가능하던 기능을 여러개 등록이 가능하게 만들었고,
이를 통한 검색도 가능하게 했다.
해시태그를 누르면 관련된 게시물 목록이 보이게 하는 기능도 추가했다.
#57 에 이어서 구현과 테스트까지 완료함.

This closes #67 